### PR TITLE
Make RPC calls via provider. Remove web3

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ var Blockchain = {
     }, callback)
   },
 
-  getBlockByHash: function(blockNumber, provider, callback){
-    var params = [blockNumber, true];
+  getBlockByHash: function(blockHash, provider, callback){
+    var params = [blockHash, true];
     provider.sendAsync({
       jsonrpc: '2.0',
       method: 'eth_getBlockByHash',

--- a/index.js
+++ b/index.js
@@ -1,8 +1,25 @@
-// TODO: remove web3 requirement
-// Call functions directly on the provider.
-var Web3 = require("web3");
-
 var Blockchain = {
+
+  getBlockByNumber: function(blockNumber, provider, callback){
+    var params = [blockNumber, true];
+    provider.sendAsync({
+      jsonrpc: '2.0',
+      method: 'eth_getBlockByNumber',
+      params: params,
+      id: Date.now(),
+    }, callback)
+  },
+
+  getBlockByHash: function(blockNumber, provider, callback){
+    var params = [blockNumber, true];
+    provider.sendAsync({
+      jsonrpc: '2.0',
+      method: 'eth_getBlockByHash',
+      params: params,
+      id: Date.now(),
+    }, callback)
+  },
+
   parse: function(uri) {
     var parsed = {};
     if (uri.indexOf("blockchain://") != 0) return parsed;
@@ -18,36 +35,38 @@ var Blockchain = {
   },
 
   asURI: function(provider, callback) {
-    var web3 = new Web3(provider);
+    var self = this;
+    var genesis;
 
-    web3.eth.getBlock(0, function(err, genesis) {
+    self.getBlockByNumber("0x0", provider, function(err, response) {
       if (err) return callback(err);
+      genesis = response.result;
 
-      web3.eth.getBlock("latest", function(err, latest) {
+      self.getBlockByNumber("latest", provider, function(err, response) {
         if (err) return callback(err);
-
+        latest = response.result;
         var url = "blockchain://" + genesis.hash.replace("0x", "") + "/block/" + latest.hash.replace("0x", "");
-
         callback(null, url);
       });
     });
   },
 
   matches: function(uri, provider, callback) {
-    uri = this.parse(uri);
+    var self = this;
+    uri = self.parse(uri);
 
     var expected_genesis = uri.genesis_hash;
     var expected_block = uri.block_hash;
 
-    var web3 = new Web3(provider);
-
-    web3.eth.getBlock(0, function(err, block) {
+    self.getBlockByNumber("0x0", provider, function(err, response) {
       if (err) return callback(err);
+      var block = response.result;
       if (block.hash != expected_genesis) return callback(null, false);
 
-      web3.eth.getBlock(expected_block, function(err, block) {
+      self.getBlockByHash(expected_block, provider, function(err, response) {
         // Treat an error as if the block didn't exist. This is because
         // some clients respond differently.
+        var block = response.result;
         if (err || block == null) {
           return callback(null, false);
         }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,5 @@
     "url": "https://github.com/trufflesuite/truffle-blockchain-utils/issues"
   },
   "homepage": "https://github.com/trufflesuite/truffle-blockchain-utils#readme",
-  "dependencies": {
-    "web3": "^0.20.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
These changes are necessary for the tests on the `web3 1.0` branch at `truffle-contract` to succeed because there's some kind of old/new web3 mismatch thing happening (explanation too vague? see [here](https://travis-ci.org/trufflesuite/truffle-contract/jobs/335905604#L2045) for possibly interpretable details.)  

In any case just implements what's proposed at the top of `index.js` in a TODO note - namely decouples these utilities from `web3`.   