### PR TITLE
Update for Web3 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var Blockchain = {
 
   getBlockByNumber: function(blockNumber, provider, callback){
     var params = [blockNumber, true];
-    provider.sendAsync({
+    provider.send({
       jsonrpc: '2.0',
       method: 'eth_getBlockByNumber',
       params: params,
@@ -12,7 +12,7 @@ var Blockchain = {
 
   getBlockByHash: function(blockHash, provider, callback){
     var params = [blockHash, true];
-    provider.sendAsync({
+    provider.send({
       jsonrpc: '2.0',
       method: 'eth_getBlockByHash',
       params: params,


### PR DESCRIPTION
Web3 1.0 abandons the distinction between `send` and `sendAsync` and prefers `send`. Have renamed the provider's method upstream to reflect that pattern. 